### PR TITLE
Adds reasoning enabled

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -248,6 +248,9 @@ type PostOpenrouterReasoningRequest struct {
 
 	// Optional: Default is false. All models support this.
 	Exclude bool `json:"exclude"` // // Set to true to exclude reasoning tokens from response
+
+	// Or enable reasoning with the default parameters:
+	Enabled bool `json:"enabled"` // Default: inferred from `effort` or `max_tokens`
 }
 
 type StreamOptions struct {


### PR DESCRIPTION
Adds 'enabled' in PostOpenrouterReasoningRequest

Trying to fix this error
```
chat request failed: status_code: 400, 
url: https://openrouter.ai/api/v1/chat/completions 
body: {"error":{"message":"\"reasoning.max_tokens\" must be less than total tokens and greater than or equal to 1024",
"code":400,
"metadata":{"provider_name":"Google"}
}
```