### PR TITLE
feat: support anthropic claude,openAI cache control config

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -94,6 +94,11 @@ type ChatMessagePart struct {
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
 }
 
+type CacheControlConfig struct {
+	Type string `json:"type,omitempty"`
+	TTL  string `json:"ttl,omitempty"`
+}
+
 type ChatCompletionMessage struct {
 	Role         string `json:"role"`
 	Content      string `json:"content,omitempty"`
@@ -122,6 +127,9 @@ type ChatCompletionMessage struct {
 
 	// Openrouter style reasoning
 	Reasoning string `json:"reasoning,omitempty"`
+
+	// Cache Control
+	CacheControl *CacheControlConfig `json:"cache_control,omitempty"`
 }
 
 func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
@@ -130,31 +138,33 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 	}
 	if len(m.MultiContent) > 0 {
 		msg := struct {
-			Role             string            `json:"role"`
-			Content          string            `json:"-"`
-			Refusal          string            `json:"refusal,omitempty"`
-			MultiContent     []ChatMessagePart `json:"content,omitempty"`
-			Name             string            `json:"name,omitempty"`
-			ReasoningContent string            `json:"reasoning_content,omitempty"`
-			FunctionCall     *FunctionCall     `json:"function_call,omitempty"`
-			ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`
-			ToolCallID       string            `json:"tool_call_id,omitempty"`
-			Reasoning        string            `json:"reasoning,omitempty"`
+			Role             string              `json:"role"`
+			Content          string              `json:"-"`
+			Refusal          string              `json:"refusal,omitempty"`
+			MultiContent     []ChatMessagePart   `json:"content,omitempty"`
+			Name             string              `json:"name,omitempty"`
+			ReasoningContent string              `json:"reasoning_content,omitempty"`
+			FunctionCall     *FunctionCall       `json:"function_call,omitempty"`
+			ToolCalls        []ToolCall          `json:"tool_calls,omitempty"`
+			ToolCallID       string              `json:"tool_call_id,omitempty"`
+			Reasoning        string              `json:"reasoning,omitempty"`
+			CacheControl     *CacheControlConfig `json:"cache_control,omitempty"`
 		}(m)
 		return json.Marshal(msg)
 	}
 
 	msg := struct {
-		Role             string            `json:"role"`
-		Content          string            `json:"content,omitempty"`
-		Refusal          string            `json:"refusal,omitempty"`
-		MultiContent     []ChatMessagePart `json:"-"`
-		Name             string            `json:"name,omitempty"`
-		ReasoningContent string            `json:"reasoning_content,omitempty"`
-		FunctionCall     *FunctionCall     `json:"function_call,omitempty"`
-		ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`
-		ToolCallID       string            `json:"tool_call_id,omitempty"`
-		Reasoning        string            `json:"reasoning,omitempty"`
+		Role             string              `json:"role"`
+		Content          string              `json:"content,omitempty"`
+		Refusal          string              `json:"refusal,omitempty"`
+		MultiContent     []ChatMessagePart   `json:"-"`
+		Name             string              `json:"name,omitempty"`
+		ReasoningContent string              `json:"reasoning_content,omitempty"`
+		FunctionCall     *FunctionCall       `json:"function_call,omitempty"`
+		ToolCalls        []ToolCall          `json:"tool_calls,omitempty"`
+		ToolCallID       string              `json:"tool_call_id,omitempty"`
+		Reasoning        string              `json:"reasoning,omitempty"`
+		CacheControl     *CacheControlConfig `json:"cache_control,omitempty"`
 	}(m)
 	return json.Marshal(msg)
 }
@@ -165,12 +175,13 @@ func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 		Content          string `json:"content"`
 		Refusal          string `json:"refusal,omitempty"`
 		MultiContent     []ChatMessagePart
-		Name             string        `json:"name,omitempty"`
-		ReasoningContent string        `json:"reasoning_content,omitempty"`
-		FunctionCall     *FunctionCall `json:"function_call,omitempty"`
-		ToolCalls        []ToolCall    `json:"tool_calls,omitempty"`
-		ToolCallID       string        `json:"tool_call_id,omitempty"`
-		Reasoning        string        `json:"reasoning,omitempty"`
+		Name             string              `json:"name,omitempty"`
+		ReasoningContent string              `json:"reasoning_content,omitempty"`
+		FunctionCall     *FunctionCall       `json:"function_call,omitempty"`
+		ToolCalls        []ToolCall          `json:"tool_calls,omitempty"`
+		ToolCallID       string              `json:"tool_call_id,omitempty"`
+		Reasoning        string              `json:"reasoning,omitempty"`
+		CacheControl     *CacheControlConfig `json:"cache_control,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(bs, &msg); err == nil {
@@ -180,14 +191,15 @@ func (m *ChatCompletionMessage) UnmarshalJSON(bs []byte) error {
 	multiMsg := struct {
 		Role             string `json:"role"`
 		Content          string
-		Refusal          string            `json:"refusal,omitempty"`
-		MultiContent     []ChatMessagePart `json:"content"`
-		Name             string            `json:"name,omitempty"`
-		ReasoningContent string            `json:"reasoning_content,omitempty"`
-		FunctionCall     *FunctionCall     `json:"function_call,omitempty"`
-		ToolCalls        []ToolCall        `json:"tool_calls,omitempty"`
-		ToolCallID       string            `json:"tool_call_id,omitempty"`
-		Reasoning        string            `json:"reasoning,omitempty"`
+		Refusal          string              `json:"refusal,omitempty"`
+		MultiContent     []ChatMessagePart   `json:"content"`
+		Name             string              `json:"name,omitempty"`
+		ReasoningContent string              `json:"reasoning_content,omitempty"`
+		FunctionCall     *FunctionCall       `json:"function_call,omitempty"`
+		ToolCalls        []ToolCall          `json:"tool_calls,omitempty"`
+		ToolCallID       string              `json:"tool_call_id,omitempty"`
+		Reasoning        string              `json:"reasoning,omitempty"`
+		CacheControl     *CacheControlConfig `json:"cache_control,omitempty"`
 	}{}
 	if err := json.Unmarshal(bs, &multiMsg); err != nil {
 		return err
@@ -387,8 +399,9 @@ type Tool struct {
 }
 
 type ToolChoice struct {
-	Type     ToolType     `json:"type"`
-	Function ToolFunction `json:"function,omitempty"`
+	Type         ToolType            `json:"type"`
+	Function     ToolFunction        `json:"function,omitempty"`
+	CacheControl *CacheControlConfig `json:"cache_control,omitempty"`
 }
 
 type ToolFunction struct {

--- a/chat.go
+++ b/chat.go
@@ -94,6 +94,8 @@ type ChatMessagePart struct {
 	ImageURL *ChatMessageImageURL `json:"image_url,omitempty"`
 }
 
+// Claude Cache Control Config
+// https://docs.claude.com/en/docs/build-with-claude/prompt-caching
 type CacheControlConfig struct {
 	Type string `json:"type,omitempty"`
 	TTL  string `json:"ttl,omitempty"`
@@ -338,6 +340,11 @@ type ChatCompletionRequest struct {
 	IncludeReasoning bool `json:"include_reasoning,omitempty"`
 
 	Reasoning *PostOpenrouterReasoningRequest `json:"reasoning,omitempty"`
+
+	// OpenAI cache key
+	// OpenAI cache automatically and can be triggered with key (to make sure its only triggered from the same request)
+	// https://platform.openai.com/docs/api-reference/responses/create#responses-create-prompt_cache_key
+	PromptCacheKey string `json:"prompt_cache_key,omitempty"`
 }
 
 type PostOpenrouterProviderRequest struct {

--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ type Usage struct {
 	TotalTokens             int                      `json:"total_tokens"`
 	PromptTokensDetails     *PromptTokensDetails     `json:"prompt_tokens_details"`
 	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details"`
+	CacheReadInputTokens    int                      `json:"cache_read_input_tokens"`
 }
 
 // CompletionTokensDetails Breakdown of tokens used in a completion.


### PR DESCRIPTION
This PR adds support for Claude Code’s prompt cache capability by introducing new request/response fields in the client.
The added fields allow developers to leverage caching in Claude’s code model prompts, which helps reduce cost and latency when reusing prompt context.

https://docs.claude.com/en/docs/build-with-claude/prompt-caching

Also add OpenAI control key for cache support, openAI cache is automatic without any requirement in the request.
https://platform.openai.com/docs/api-reference/responses/create#responses-create-prompt_cache_key