### PR TITLE
add extra headers

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -332,6 +332,11 @@ type ChatCompletionRequest struct {
 	Reasoning *PostOpenrouterReasoningRequest `json:"reasoning,omitempty"`
 
 	ExtraBody *PostAlibabaCloudExtraBody `json:"extra_body,omitempty"`
+
+	// ExtraHeaders allows you to add custom HTTP headers to the request.
+	// These headers will be sent along with the standard headers.
+	// Note: This field is not sent in the JSON body of the request.
+	ExtraHeaders http.Header `json:"-"`
 }
 
 type PostOpenrouterProviderRequest struct {
@@ -532,11 +537,19 @@ func (c *Client) CreateChatCompletion(
 		return
 	}
 
+	requestOptions := []requestOption{
+		withBody(request),
+	}
+
+	if request.ExtraHeaders != nil {
+		requestOptions = append(requestOptions, withExtraHeaders(request.ExtraHeaders))
+	}
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,
 		c.fullURL(urlSuffix, withModel(request.Model)),
-		withBody(request),
+		requestOptions...,
 	)
 	if err != nil {
 		return

--- a/chat_stream.go
+++ b/chat_stream.go
@@ -100,11 +100,19 @@ func (c *Client) CreateChatCompletionStream(
 		return
 	}
 
+	requestOptions := []requestOption{
+		withBody(request),
+	}
+
+	if request.ExtraHeaders != nil {
+		requestOptions = append(requestOptions, withExtraHeaders(request.ExtraHeaders))
+	}
+
 	req, err := c.newRequest(
 		ctx,
 		http.MethodPost,
 		c.fullURL(urlSuffix, withModel(request.Model)),
-		withBody(request),
+		requestOptions...,
 	)
 	if err != nil {
 		return nil, err

--- a/chat_test.go
+++ b/chat_test.go
@@ -1126,6 +1126,55 @@ func TestAzureAnthropicChatCompletionUsesMessagesEndpoint(t *testing.T) {
 	}
 }
 
+// TestChatCompletionsWithExtraHeaders Tests that custom headers are properly sent with the request.
+func TestChatCompletionsWithExtraHeaders(t *testing.T) {
+	client, server, teardown := setupOpenAITestServer()
+	defer teardown()
+
+	const customHeader1 = "X-Custom-Header-1"
+	const customHeader1Value = "custom-value-1"
+	const customHeader2 = "X-Custom-Header-2"
+	const customHeader2Value = "custom-value-2"
+
+	// Track whether headers were received
+	var receivedHeader1, receivedHeader2 bool
+
+	server.RegisterHandler("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		// Check if custom headers are present in the request
+		if r.Header.Get(customHeader1) == customHeader1Value {
+			receivedHeader1 = true
+		}
+		if r.Header.Get(customHeader2) == customHeader2Value {
+			receivedHeader2 = true
+		}
+		handleChatCompletionEndpoint(w, r)
+	})
+
+	extraHeaders := http.Header{}
+	extraHeaders.Add(customHeader1, customHeader1Value)
+	extraHeaders.Add(customHeader2, customHeader2Value)
+
+	_, err := client.CreateChatCompletion(context.Background(), openai.ChatCompletionRequest{
+		MaxTokens: 5,
+		Model:     openai.GPT3Dot5Turbo,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: "Hello!",
+			},
+		},
+		ExtraHeaders: extraHeaders,
+	})
+	checks.NoError(t, err, "CreateChatCompletion error")
+
+	if !receivedHeader1 {
+		t.Errorf("expected custom header %s to be received", customHeader1)
+	}
+	if !receivedHeader2 {
+		t.Errorf("expected custom header %s to be received", customHeader2)
+	}
+}
+
 func TestAzureAnthropicChatCompletionStreamUsesMessagesEndpoint(t *testing.T) {
 	// Test that Azure Anthropic API type uses /v1/messages endpoint for streaming
 	server := test.NewTestServer()

--- a/client.go
+++ b/client.go
@@ -110,6 +110,16 @@ func withBetaAssistantVersion(version string) requestOption {
 	}
 }
 
+func withExtraHeaders(extraHeaders http.Header) requestOption {
+	return func(args *requestOptions) {
+		for key, values := range extraHeaders {
+			for _, value := range values {
+				args.header.Add(key, value)
+			}
+		}
+	}
+}
+
 func (c *Client) newRequest(ctx context.Context, method, url string, setters ...requestOption) (*http.Request, error) {
 	// Default Options
 	args := &requestOptions{


### PR DESCRIPTION
Add extra headers so that we can bypass the moderation from alibabacloud.
```
extra_headers={
		'X-DashScope-DataInspection':
		'{"input": "disable", "output": "disable"}'
	},
```